### PR TITLE
Exclude :asn1ct from project

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,8 @@ defmodule Wax.MixProject do
         extras: ["README.md", "CHANGELOG.md"]
       ],
       package: package(),
-      source_url: "https://github.com/tanguilp/wax"
+      source_url: "https://github.com/tanguilp/wax",
+      xref: [exclude: [:asn1ct]]
     ]
   end
 


### PR DESCRIPTION
When included in another project, a compilation warning is issued that `:asn1ct.compile/2` is used, but is not included as a dependency. This excludes the application from being detected by dependent applications.

I considered adding it to `:extra_applications`, but thought that since it's only used by the included Mix task, that it was more clean to just exclude the xref.

Anyways, no worries if you don't want this change. I figured I'd submit it in case you were open to it.