### PR TITLE
Use system time for timeout calculation

### DIFF
--- a/lib/wax.ex
+++ b/lib/wax.ex
@@ -381,7 +381,7 @@ defmodule Wax do
   end
 
   defp not_expired?(challenge) do
-    current_time = :erlang.monotonic_time(:second)
+    current_time = System.system_time(:second)
 
     if current_time - challenge.issued_at < challenge.timeout do
       :ok

--- a/lib/wax/challenge.ex
+++ b/lib/wax/challenge.ex
@@ -71,7 +71,7 @@ defmodule Wax.Challenge do
     opts =
       opts
       |> Keyword.put(:bytes, random_bytes())
-      |> Keyword.put(:issued_at, :erlang.monotonic_time(:second))
+      |> Keyword.put(:issued_at, System.system_time(:second))
 
     opts_from_env = Application.get_all_env(:wax_) |> Keyword.take(@opt_names)
 

--- a/test/wax_test.exs
+++ b/test/wax_test.exs
@@ -31,7 +31,7 @@ defmodule WaxTest do
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       # this example doesn't have a valid attestation root in FIDO2 MDS
       verify_trust_root: false,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -73,7 +73,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -121,7 +121,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -169,7 +169,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -221,7 +221,7 @@ defmodule WaxTest do
   #    rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
   #    trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
   #    verify_trust_root: true,
-  #    issued_at: :erlang.monotonic_time(:second),
+  #    issued_at: System.system_time(:second),
   #    timeout: 100,
   #    silent_authentication_enabled: false
   #  }
@@ -261,7 +261,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: false,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -303,7 +303,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -385,7 +385,7 @@ defmodule WaxTest do
       token_binding_status: nil,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -467,7 +467,7 @@ defmodule WaxTest do
       token_binding_status: nil,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }
@@ -516,7 +516,7 @@ defmodule WaxTest do
       rp_id: URI.parse(Map.get(test_client_data, :origin)).host,
       trusted_attestation_types: [:none, :basic, :uncertain, :attca, :self],
       verify_trust_root: true,
-      issued_at: :erlang.monotonic_time(:second),
+      issued_at: System.system_time(:second),
       timeout: 100,
       silent_authentication_enabled: false
     }


### PR DESCRIPTION
Fixes https://github.com/tanguilp/wax/issues/38

`System.system_time/1` seems to be the best option, as it's kind of corrected and can be configured (even if not the default) to be monotonic AFAIK.

The problem with using monotonic time is that it's different on each machine of a cluster.