### PR TITLE
Allow valid_origin? to accept subdomains

### DIFF
--- a/lib/wax.ex
+++ b/lib/wax.ex
@@ -415,7 +415,11 @@ defmodule Wax do
   end
 
   defp valid_origin?(client_data, challenge) do
-    if client_data.origin == challenge.origin do
+    client_origin = URI.parse(client_data.origin)
+    challenge_origin = URI.parse(challenge.origin)
+
+    if client_origin.scheme == challenge_origin.scheme &&
+         String.ends_with?(client_origin.host, challenge.rp_id) do
       :ok
     else
       {:error, %Wax.InvalidClientDataError{reason: :origin_mismatch}}


### PR DESCRIPTION
I am trying to process webauth requests on my primary and subdomains. The current checks are very strict on the domain, but setting the rp_id should allow you to process subdomains as well. The change I am proposing should abide by the webauth rules about origin/rp_id and accomplish the following:

- Credentials bound to RP ID "example.com" can be used to authenticate on https://example.com/ and https://subdomain.example.com/
- Credentials bound to "subdomain.example.com" can be used on https://subdomain.example.com/ but NOT on https://example.com/
- Credentials bound to "example.com" CANNOT be used on https://example.org/

There is probably a better way to accomplish this though, open to suggestions! 