### PR TITLE
Fix warnings with Elixir 1.17 & OTP 27

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,3 +1,3 @@
-use Mix.Config
+import Config
 
-import_config "#{Mix.env()}.exs"
+import_config "#{config_env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :wax_,
   origin: "http://localhost:4000",

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,4 +1,4 @@
-use Mix.Config
+import Config
 
 config :wax_,
   origin: "http://localhost:4000",

--- a/lib/wax/attestation_statement_format/tpm.ex
+++ b/lib/wax/attestation_statement_format/tpm.ex
@@ -461,7 +461,7 @@ defmodule Wax.AttestationStatementFormat.TPM do
       end
     )
     |> elem(2)
-    |> String.slice(2..-1)
+    |> String.slice(2..-1//-1)
   end
 
   defp to_erlang_curve(@tpm_ecc_nist_p192), do: :pubkey_cert_records.namedCurves(:secp192r1)

--- a/lib/wax/metadata.ex
+++ b/lib/wax/metadata.ex
@@ -275,7 +275,7 @@ defmodule Wax.Metadata do
 
     headers =
       if state[:last_modified] do
-        [{'if-modified-since', state[:last_modified]}]
+        [{~c"if-modified-since", state[:last_modified]}]
       else
         []
       end

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,5 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
-  "x509": {:hex, :x509, "0.8.5", "22b2c5dfc87b05d46595d3764f41a23fcb7360f891e0464f1a2ec118177cd4e4", [:mix], [], "hexpm", "c63eb89e8bbe8a5e21b6404ad1082faff670e38b74960297f90d023177949e07"},
+  "x509": {:hex, :x509, "0.8.10", "5d1ec6d5f4db31982f9dc34e6a1eebd631d04599e0b6c1c259f1dadd4495e11f", [:mix], [], "hexpm", "a191221665af28b9bdfff0c986ef55f80e126d8ce751bbdf6cefa846410140c0"},
 }


### PR DESCRIPTION
I'm using OTP 27 pretty much everywhere, so notice compiler warnings when building. I figured that while I was updating the compiler warnings I'd go ahead with the deprecation warnings I could find as well.

For some reason I was unable to compile on latest Elixir/Erlang with the version of x509 that was in the mix.lock, so I updated it.

Hope this is helpful for you!