### PR TITLE
Add support for custom bytes in Wax.Challenge struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ These options are:
 |`timeout`|`non_neg_integer()`|registration & authentication|`20 * 60`| The validity duration of a challenge, in seconds |
 |`android_key_allow_software_enforcement`|`boolean()`|registration|`false`| When registration is a Android key, determines whether software enforcement is acceptable (`true`) or only hardware enforcement is (`false`) |
 |`silent_authentication_enabled`|`boolean()`|authentication|`false`| See [https://github.com/fido-alliance/conformance-tools-issues/issues/434](https://github.com/fido-alliance/conformance-tools-issues/issues/434) |
+|`bytes`|`binary()`|registration & authentication|32 random bytes|Allows to optionally supply your own random bytes|
 
 ## FIDO2 Metadata
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ These options are:
 |`timeout`|`non_neg_integer()`|registration & authentication|`20 * 60`| The validity duration of a challenge, in seconds |
 |`android_key_allow_software_enforcement`|`boolean()`|registration|`false`| When registration is a Android key, determines whether software enforcement is acceptable (`true`) or only hardware enforcement is (`false`) |
 |`silent_authentication_enabled`|`boolean()`|authentication|`false`| See [https://github.com/fido-alliance/conformance-tools-issues/issues/434](https://github.com/fido-alliance/conformance-tools-issues/issues/434) |
-|`bytes`|`binary()`|registration & authentication|32 random bytes|Allows to optionally supply your own random bytes|
+|`bytes`|`binary()`|registration & authentication|random bytes|Allows to provide with your own challenge. This is **not** recommended unless you know what you're doing. Refer to the [Security considerations](#security-considerations) for more information|
 
 ## FIDO2 Metadata
 
@@ -235,6 +235,11 @@ formats by disabling it with the `verify_trust_root` option
 - This library has **not** be reviewed by independent security / FIDO2 specialists - use
 it at your own risks or blindly trust its author! If you're knowledgeable about
 FIDO2 and willing to help reviewing it, please contact the author
+- When providing your own challenge, please make sure to understand that:
+  - it explciitly violates the recommandation in the standard
+  - it exposes you to some attacks (such as replay attacks)
+  - you have no guarantee that the user understood what he has been signing (no specific browser UI
+  was presented)
 
 ## Changes
 

--- a/lib/wax.ex
+++ b/lib/wax.ex
@@ -218,7 +218,8 @@ defmodule Wax do
 
   The returned structure:
   - Contains the challenge bytes under the `bytes` key (e.g.: `challenge.bytes`). This is a
-  random value that must be used by the javascript WebAuthn call
+  random value that must be used by the javascript WebAuthn call. Optionally, you can supply
+  your own via the `:bytes` option.
   - Must be passed backed to `authenticate/5`
 
   Typically, this structure is stored in the session (cookie...) for the time the WebAuthn

--- a/lib/wax.ex
+++ b/lib/wax.ex
@@ -26,7 +26,7 @@ defmodule Wax do
   |`timeout`|`non_neg_integer()`|registration & authentication|`20 * 60`| The validity duration of a challenge, in seconds |
   |`android_key_allow_software_enforcement`|`boolean()`|registration|`false`| When registration is a Android key, determines whether software enforcement is acceptable (`true`) or only hardware enforcement is (`false`) |
   |`silent_authentication_enabled`|`boolean()`|authentication|`false`| See [https://github.com/fido-alliance/conformance-tools-issues/issues/434](https://github.com/fido-alliance/conformance-tools-issues/issues/434) |
-  |`bytes`|`binary()`|registration & authentication|32 random bytes|Allows to optionally supply your own random bytes|
+  |`bytes`|`binary()`|registration & authentication|random bytes|Allows to provide with your own challenge. This is **not** recommended unless you know what you're doing. Refer to the [Security considerations](#security-considerations) for more information|
 
   ## FIDO2 Metadata
 
@@ -70,6 +70,11 @@ defmodule Wax do
   - This library has **not** be reviewed by independent security / FIDO2 specialists - use
   it at your own risks or blindly trust its author! If you're knowledgeable about
   FIDO2 and willing to help reviewing it, please contact the author
+  - When providing your own challenge, please make sure to understand that:
+    - it explciitly violates the recommandation in the standard
+    - it exposes you to some attacks (such as replay attacks)
+    - you have no guarantee that the user understood what he has been signing (no specific browser UI
+    was presented)
   """
 
   alias Wax.Utils

--- a/lib/wax.ex
+++ b/lib/wax.ex
@@ -26,6 +26,7 @@ defmodule Wax do
   |`timeout`|`non_neg_integer()`|registration & authentication|`20 * 60`| The validity duration of a challenge, in seconds |
   |`android_key_allow_software_enforcement`|`boolean()`|registration|`false`| When registration is a Android key, determines whether software enforcement is acceptable (`true`) or only hardware enforcement is (`false`) |
   |`silent_authentication_enabled`|`boolean()`|authentication|`false`| See [https://github.com/fido-alliance/conformance-tools-issues/issues/434](https://github.com/fido-alliance/conformance-tools-issues/issues/434) |
+  |`bytes`|`binary()`|registration & authentication|32 random bytes|Allows to optionally supply your own random bytes|
 
   ## FIDO2 Metadata
 

--- a/lib/wax/challenge.ex
+++ b/lib/wax/challenge.ex
@@ -70,7 +70,7 @@ defmodule Wax.Challenge do
   def new(opts) do
     opts =
       opts
-      |> Keyword.put(:bytes, random_bytes())
+      |> Keyword.put_new(:bytes, random_bytes())
       |> Keyword.put(:issued_at, System.system_time(:second))
 
     opts_from_env = Application.get_all_env(:wax_) |> Keyword.take(@opt_names)

--- a/test/wax/challenge_test.exs
+++ b/test/wax/challenge_test.exs
@@ -1,13 +1,15 @@
-defmodule Wax.ChanllengeTest do
+defmodule Wax.ChallengeTest do
   use ExUnit.Case, async: true
 
   alias Wax.Challenge
 
-  test "generates bytes" do
-    assert Challenge.new([]).bytes
-  end
+  describe "new/1" do
+    test "generates bytes" do
+      assert Challenge.new([]).bytes
+    end
 
-  test "does not override bytes when provided as an option" do
-    assert %{bytes: "abcd"} = Challenge.new(bytes: "abcd")
+    test "does not override bytes when provided as an option" do
+      assert %{bytes: "abcd"} = Challenge.new(bytes: "abcd")
+    end
   end
 end

--- a/test/wax/challenge_test.exs
+++ b/test/wax/challenge_test.exs
@@ -1,0 +1,13 @@
+defmodule Wax.ChanllengeTest do
+  use ExUnit.Case, async: true
+
+  alias Wax.Challenge
+
+  test "generates bytes" do
+    assert Challenge.new([]).bytes
+  end
+
+  test "does not override bytes when provided as an option" do
+    assert %{bytes: "abcd"} = Challenge.new(bytes: "abcd")
+  end
+end

--- a/test/wax/challenge_test.exs
+++ b/test/wax/challenge_test.exs
@@ -5,7 +5,8 @@ defmodule Wax.ChallengeTest do
 
   describe "new/1" do
     test "generates bytes" do
-      assert Challenge.new([]).bytes
+      %{bytes: bytes} = Challenge.new([])
+      assert byte_size(bytes) == 32
     end
 
     test "does not override bytes when provided as an option" do


### PR DESCRIPTION
This PR adds support for supplying custom bytes when creating a `%Wax.Challenge{}` struct.

This enhancement is significant because these bytes (referred to as "cryptographic challenge" in the [Passkey standard](https://developer.mozilla.org/en-US/docs/Web/API/PublicKeyCredentialRequestOptions#challenge)) are signed by the authenticator, with the signature returned as part of the [AuthenticatorAssertionResponse.signature](https://developer.mozilla.org/en-US/docs/Web/API/AuthenticatorAssertionResponse/signature).

The practical value is that this signature creates a cryptographic connection between the passkey and the provided bytes, serving as strong proof of an activity. For example, in our workflow where passkey presentation is required before performing a legal action, we can use the resulting signature as irrefutable proof that a user has taken a very specific action.